### PR TITLE
experimental: ChatLinkIcons support

### DIFF
--- a/API/Modifiers.lua
+++ b/API/Modifiers.lua
@@ -1,0 +1,12 @@
+--[[
+    ChatLinkIcons integration.
+    You can turn off each individual icon type off in in ChatLinkIcons options.
+
+    Thanks to SDPhantom for making API functions!
+]]
+EventUtil.ContinueOnAddOnLoaded("ChatLinkIcons", function()
+    local ConvertLinks = ChatLinkIcons.ConvertLinks
+    Chattynator.API.AddModifier(function(data) 
+        data.text = ConvertLinks(data.text) 
+    end)
+end)

--- a/Chattynator.toc
+++ b/Chattynator.toc
@@ -40,6 +40,7 @@ Core/Dialogs.lua
 
 API/Main.lua
 API/CustomTab.lua
+API/Modifiers.lua
 
 Display/Main.lua
 Display/Tabs.lua


### PR DESCRIPTION
Integration for [ChatLinkIcons](https://www.curseforge.com/wow/addons/chatlinkicons).

From their readme.txt:

```
-= API Functions =-
ConvertedString = ChatLinkIcons.ConvertLinks(RawString)
	Adds icons to links contained in a string.

ChatLinkIcons.RegisterForLinkUpates(CallbackFunc)
ChatLinkIcons.UnregisterForLinkUpates(CallbackFunc)
	Registers/Unregisters a callback function that is called when previously-converted links are to be updated.
	Multiple unique callbacks may be registered. Duplicate registrations silently fail.
	Errors in callback functions still show, but return execution back to ChatLinkIcons.
	Callback functions are not passed any arguments at this time.
```

- Solves feature request on discord, https://discord.com/channels/1415792161806614550/1432080207916830862
- Solves #180, and possibly #70. ChatLinkIcons is cross wow environment compatible, I think.