### PR TITLE
Fix edit box position not applying on login/reload

### DIFF
--- a/Core/Overrides.lua
+++ b/Core/Overrides.lua
@@ -142,6 +142,7 @@ function addonTable.Core.ApplyOverrides()
           hooksecurefunc(tabButton, "SetParent", function(self) SetParent(self, addonTable.hiddenFrame) end)
         end
         _G["ChatFrame1Tab"].IsVisible = function() return true end -- Workaround for TSM assuming chat tabs are always visible
+        addonTable.allChatFrames[1]:UpdateEditBox()
       end)
     end
   end)


### PR DESCRIPTION
`EDIT_BOX_POSITION` was being set correctly by `UpdateEditBox()` during `PLAYER_LOGIN`, but Blizzard's chat positioning code running during `PLAYER_ENTERING_WORLD` was re-anchoring `ChatFrame1EditBox` afterward, overwriting the custom position.

Fixes by calling `UpdateEditBox()` at the end of the `C_Timer.After(0)` block inside `PLAYER_ENTERING_WORLD`, ensuring it runs last allowing the position to take effect.