### PR TITLE
Integrate TwitchEmotes support

### DIFF
--- a/API/TwitchEmotes.lua
+++ b/API/TwitchEmotes.lua
@@ -1,0 +1,82 @@
+--[[
+    TwitchEmotes integration.
+    Applies TwitchEmotes replacements to Chattynator-rendered messages and
+    updates animated emotes inside Chattynator's custom scrolling frames.
+]]
+local addonTable = select(2, ...)
+
+EventUtil.ContinueOnAddOnLoaded("TwitchEmotes", function()
+  local elapsedSinceLastUpdate = 0
+  local statlessMessageID = "chattynator_twitchemotes"
+  local countedMessageIDs = {}
+  local seededExistingMessageIDs = false
+
+  local function SeedExistingMessageIDs()
+    if seededExistingMessageIDs or not addonTable.Messages or not addonTable.Messages.messages then
+      return
+    end
+    seededExistingMessageIDs = true
+
+    for _, message in ipairs(addonTable.Messages.messages) do
+      countedMessageIDs[message.id] = true
+    end
+  end
+
+  local function CountMessageStats(data)
+    SeedExistingMessageIDs()
+
+    if countedMessageIDs[data.id] or type(UpdateEmoteStats) ~= "function" then
+      return
+    end
+    countedMessageIDs[data.id] = true
+
+    local senderGUID = data.playerGUID or data.typeInfo.playerGUID
+    local localPlayerGUID = UnitGUID("player")
+    local isSent = localPlayerGUID ~= nil and localPlayerGUID == senderGUID
+    local delimiters = "%s,'<>?-%.!"
+
+    for word in string.gmatch(data.text, "[^" .. delimiters .. "]+") do
+      local emote = TwitchEmotes_emoticons[word]
+      if emote and TwitchEmotes_defaultpack[emote] ~= nil then
+        UpdateEmoteStats(emote, false, isSent, not isSent)
+      end
+    end
+  end
+
+  Emoticons_RunReplacement("", nil, statlessMessageID)
+
+  Chattynator.API.AddModifier(function(data)
+    if type(Emoticons_RunReplacement) ~= "function" then
+      return
+    end
+    if not Emoticons_Settings[data.typeInfo.event] then
+      return
+    end
+
+    CountMessageStats(data)
+    data.text = Emoticons_RunReplacement(data.text, data.playerGUID or data.typeInfo.playerGUID, statlessMessageID)
+  end)
+  C_Timer.After(0, SeedExistingMessageIDs)
+
+  hooksecurefunc("TwitchEmotesAnimator_OnUpdate", function(_, elapsed)
+    if type(TwitchEmotesAnimator_UpdateEmoteInFontString) ~= "function" or not addonTable.allChatFrames then
+      return
+    end
+    elapsedSinceLastUpdate = elapsedSinceLastUpdate + (elapsed or 0)
+    if elapsedSinceLastUpdate < 0.033 then
+      return
+    end
+    elapsedSinceLastUpdate = 0
+
+    for _, chatFrame in ipairs(addonTable.allChatFrames) do
+      local scrollingMessages = chatFrame.ScrollingMessages
+      if chatFrame:IsShown() and scrollingMessages and scrollingMessages:IsShown() then
+        for _, visibleLine in ipairs(scrollingMessages.visibleLines) do
+          if visibleLine.messageInfo ~= TwitchEmotes_HoverMessageInfo then
+            TwitchEmotesAnimator_UpdateEmoteInFontString(visibleLine, 28, 28)
+          end
+        end
+      end
+    end
+  end)
+end)

--- a/Chattynator.toc
+++ b/Chattynator.toc
@@ -1,6 +1,6 @@
 ## Interface: 120005, 120001, 50503, 38001, 20505, 11508
 ## Title: Chattynator
-## Version: @project-version@
+## Version: 203
 ## Author: plusmouse
 ## IconTexture: Interface\AddOns\Chattynator\Assets\Logo.png
 ## SavedVariables: CHATTYNATOR_CONFIG, CHATTYNATOR_MESSAGE_LOG
@@ -41,6 +41,7 @@ Core/Dialogs.lua
 API/Main.lua
 API/CustomTab.lua
 API/Modifiers.lua
+API/TwitchEmotes.lua
 
 Display/Main.lua
 Display/Tabs.lua

--- a/Core/Initialize.lua
+++ b/Core/Initialize.lua
@@ -126,6 +126,7 @@ function addonTable.Core.Initialize()
     storecategory = false,
     talent = true,
     talentbuild = false,
+    tel = true,
     trade = false,
     transmogappearance = false,
     transmogillusion = false,
@@ -135,17 +136,23 @@ function addonTable.Core.Initialize()
     worldmap = false,
   }
 
-  ChattynatorHyperlinkHandler:SetScript("OnHyperlinkEnter", function(_, hyperlink)
+  ChattynatorHyperlinkHandler:SetScript("OnHyperlinkEnter", function(frame, hyperlink, ...)
     local type = hyperlink:match("^(.-):")
-    if validLinks[type] then
+    if type == "tel" and Emoticons_OnHyperlinkEnter then
+      Emoticons_OnHyperlinkEnter(frame, hyperlink, ...)
+    elseif validLinks[type] then
       GameTooltip:SetOwner(ChattynatorHyperlinkHandler:GetParent(), "ANCHOR_CURSOR_RIGHT")
       GameTooltip:SetHyperlink(hyperlink)
       GameTooltip:Show()
     end
   end)
 
-  ChattynatorHyperlinkHandler:SetScript("OnHyperlinkLeave", function()
-    GameTooltip:Hide()
+  ChattynatorHyperlinkHandler:SetScript("OnHyperlinkLeave", function(frame, ...)
+    if Emoticons_OnHyperlinkLeave then
+      Emoticons_OnHyperlinkLeave(frame, ...)
+    else
+      GameTooltip:Hide()
+    end
   end)
 
   addonTable.Messages = CreateFrame("Frame")

--- a/Core/Messages.lua
+++ b/Core/Messages.lua
@@ -824,8 +824,10 @@ function addonTable.MessagesMonitorMixin:AddMessage(text, r, g, b, _, _, _, _, _
     color = {r = r or 1, g = g or 1, b = b or 1},
     timestamp = time(),
     typeInfo = self.incomingType or {type = "ADDON", event = "NONE"},
+    playerGUID = self.playerGUID,
     recordedBy = addonTable.Data.CharacterName or "",
   }
+  data.typeInfo.playerGUID = self.playerGUID
   if addonTable.Data.CharacterName == nil then
     table.insert(self.awaitingRecorderSet, {data, self.messageCount + 1})
   end

--- a/Display/ScrollingMessages.lua
+++ b/Display/ScrollingMessages.lua
@@ -90,6 +90,7 @@ end
 
 function addonTable.Display.ScrollingMessagesMixin:Clear()
   for _, fs in ipairs(self.visibleLines) do
+    fs.messageInfo = nil
     fs.timestamp = nil
     fs.bar = nil
   end
@@ -215,6 +216,7 @@ function addonTable.Display.ScrollingMessagesMixin:Render(newMessages)
     local start = math.min(#messages, self.scrollIndex)
     while #self.visibleLines > 0 and #self.visibleLines >= lines - math.min(lines, #messages) do
       local fs = table.remove(self.visibleLines)
+      fs.messageInfo = nil
       if fs.timestamp then
         self.pool:Release(fs.timestamp)
         fs.timestamp = nil
@@ -239,6 +241,9 @@ function addonTable.Display.ScrollingMessagesMixin:Render(newMessages)
         fs:SetTextColor(m.color.r, m.color.g, m.color.b)
         fs:SetTextScale(addonTable.Messages.scalingFactor)
         fs:SetNonSpaceWrap(true)
+        fs.messageInfo = {
+          message = m.text,
+        }
         fs:SetAlpha(1)
         fs.animationTime = nil
         fs.animationStart = nil


### PR DESCRIPTION
Add TwitchEmotes integration and support for animated emotes in custom scrolling frames. New API/TwitchEmotes.lua applies Emoticons_RunReplacement to Chattynator messages, updates emote stats, and hooks the TwitchEmotes animator to refresh emotes in visible ScrollingMessages lines. Update Chattynator.toc to include the new API file and bump version. Initialize.lua: register "tel" hyperlink handling to forward hover/leave to Emoticons handlers when available. Messages.lua: store playerGUID on message data and mirror it to typeInfo.playerGUID so emote replacements/stats can identify senders. ScrollingMessages.lua: ensure messageInfo is set for rendered lines and cleared when recycling so TwitchEmotes can update font strings correctly.